### PR TITLE
在 send_auth 时使用主播 uid 作为默认 uid

### DIFF
--- a/blivedm/client.py
+++ b/blivedm/client.py
@@ -421,7 +421,7 @@ class BLiveClient:
         发送认证包
         """
         auth_params = {
-            'uid': self._uid,
+            'uid': self._uid or self.room_owner_uid or 0,
             'roomid': self._room_id,
             'protover': 3,
             'platform': 'web',


### PR DESCRIPTION
这可以帮助解决 xfgryujk/blivechat#111 （针对服务器转发）