### PR TITLE
从弹幕消息的 dm_v2 字段读取用户头像 url

### DIFF
--- a/blivedm/handlers.py
+++ b/blivedm/handlers.py
@@ -61,7 +61,7 @@ class BaseHandler(HandlerInterface):
         return self._on_heartbeat(client, models.HeartbeatMessage.from_command(command['data']))
 
     def __danmu_msg_callback(self, client: client_.BLiveClient, command: dict):
-        return self._on_danmaku(client, models.DanmakuMessage.from_command(command['info']))
+        return self._on_danmaku(client, models.DanmakuMessage.from_command(command))
 
     def __send_gift_callback(self, client: client_.BLiveClient, command: dict):
         return self._on_gift(client, models.GiftMessage.from_command(command['data']))

--- a/blivedm/models.py
+++ b/blivedm/models.py
@@ -134,8 +134,7 @@ class DanmakuMessage:
 
         try:
             face = pb_models.DanmakuMessageV2.loads(base64.b64decode(command['dm_v2'])).user.face
-        except Exception as err:
-            print(err)
+        except:
             face = None
         """
         示例：

--- a/blivedm/models.py
+++ b/blivedm/models.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import dataclasses
 import json
+import base64
 from typing import *
+
+from . import pb_models
 
 __all__ = (
     'HeartbeatMessage',
@@ -67,6 +70,8 @@ class DanmakuMessage:
     """用户ID"""
     uname: str = None
     """用户名"""
+    face: str = None
+    """用户头像URL"""
     admin: int = None
     """是否房管"""
     vip: int = None
@@ -109,7 +114,9 @@ class DanmakuMessage:
     """舰队类型，0非舰队，1总督，2提督，3舰长"""
 
     @classmethod
-    def from_command(cls, info: dict):
+    def from_command(cls, command: dict):
+        info = command['info']
+    
         if len(info[3]) != 0:
             medal_level = info[3][0]
             medal_name = info[3][1]
@@ -125,6 +132,20 @@ class DanmakuMessage:
             mcolor = 0
             special_medal = 0
 
+        try:
+            face = pb_models.DanmakuMessageV2.loads(base64.b64decode(command['dm_v2'])).user.face
+        except Exception as err:
+            print(err)
+            face = None
+        """
+        示例：
+        {'dm_v2': 'CiIxMmM2ZDg4MGQ5Yjc3Njc3NTI1NTA1NjFjYjY0YTJmYjU5EAEYGSDP2v8HKghkODU4ZWQ3MzIG5ZGc5ZGcOMHUk+WRMU
+         jl2cv+AWIAaAFydwoG5ZGc5ZGcEm0KE3Jvb21fMTA0MTMwNTFfMzY5NDkSSmh0dHBzOi8vaTAuaGRzbGIuY29tL2Jmcy9nYXJiLzMxYj
+         I4ZjRlZjQ0NmYxNmYzZDEyZGU3ZTYzMmFlNjBhMmE0NDAyZWIucG5nGAEgASgBMKIBOKIBigEAmgEQCghFRTQ5MzU1OBCd9oulBqIBpQ
+         EIwofiBBIP5biD5LiB55Wq6IyE6IyEIkpodHRwczovL2kwLmhkc2xiLmNvbS9iZnMvZmFjZS9mY2NjY2MxOTQ3N2M0YzYzMGE0MjMwMj
+         liYmViYjk1N2NkZGFkOWMyLmpwZziQTkABWiMIERIJ54ix6I2U5LidIKS6ngYwpLqeBjikup4GQKS6ngZQAWIPCBUQ3q3iAhoGPjUwMD
+         AwagByAHoCCB+qARoIt+vxwQQSDeiNlOaenVl1cmliaXUY+8f7BA=='}
+        """
         return cls(
             mode=info[0][1],
             font_size=info[0][2],
@@ -143,6 +164,7 @@ class DanmakuMessage:
 
             uid=info[2][0],
             uname=info[2][1],
+            face=face,
             admin=info[2][2],
             vip=info[2][3],
             svip=info[2][4],

--- a/blivedm/pb_models.py
+++ b/blivedm/pb_models.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from dataclasses import dataclass, field
+from typing_extensions import Annotated
+
+from pure_protobuf.annotations import Field
+from pure_protobuf.message import BaseMessage
+
+__all__ = (
+    'DanmakuMessageV2',
+)
+
+
+@dataclass
+class UserInfo(BaseMessage):
+    face: Annotated[str, Field(4)] = None
+
+
+@dataclass
+class DanmakuMessageV2(BaseMessage):
+    user: Annotated[UserInfo, Field(20)] = field(default_factory=UserInfo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 aiohttp==3.7.4
 Brotli==1.0.9
+pure-protobuf==3.0.0a5


### PR DESCRIPTION
弹幕消息的 dm_v2 字段为 base64 编码的 protobuf 数据，去转义后丢进[解码器](https://protobuf-decoder.netlify.app/)可以看到有头像 url 。
从此处读取头像 url 能直接省去调用B站接口的开销。
```json
{
  "cmd": "DANMU_MSG",
  "info": [......],
  "dm_v2": "CiIxMmM2ZDg4MGQ5Yjc3Njc3NTI1NTA1NjFjYjY0YTJmYjU5EAEYGSDP2v8HKghkODU4ZWQ3MzIG5ZGc5ZGcOMHUk+WRMUjl2cv+AWIAaAFydwoG5ZGc5ZGcEm0KE3Jvb21fMTA0MTMwNTFfMzY5NDkSSmh0dHBzOi8vaTAuaGRzbGIuY29tL2Jmcy9nYXJiLzMxYjI4ZjRlZjQ0NmYxNmYzZDEyZGU3ZTYzMmFlNjBhMmE0NDAyZWIucG5nGAEgASgBMKIBOKIBigEAmgEQCghFRTQ5MzU1OBCd9oulBqIBpQEIwofiBBIP5biD5LiB55Wq6IyE6IyEIkpodHRwczovL2kwLmhkc2xiLmNvbS9iZnMvZmFjZS9mY2NjY2MxOTQ3N2M0YzYzMGE0MjMwMjliYmViYjk1N2NkZGFkOWMyLmpwZziQTkABWiMIERIJ54ix6I2U5LidIKS6ngYwpLqeBjikup4GQKS6ngZQAWIPCBUQ3q3iAhoGPjUwMDAwagByAHoCCB+qARoIt+vxwQQSDeiNlOaenVl1cmliaXUY+8f7BA=="
}
```
![T5}K N62)`LAQL3}7~XYZGU](https://github.com/xfgryujk/blivedm/assets/67496378/95b28618-1a67-4afe-a4a4-0cda76e1bbe0)
