### PR TITLE
修正 stop_and_close 逻辑

### DIFF
--- a/blivedm/clients/ws_base.py
+++ b/blivedm/clients/ws_base.py
@@ -176,10 +176,12 @@ class WebSocketClientBase:
         """
         便利函数，停止本客户端并释放本客户端的资源，调用后本客户端将不可用
         """
-        if self.is_running:
-            self.stop()
-            await self.join()
-        await self.close()
+        try:
+            if self.is_running:
+                self.stop()
+                await self.join()
+        finally:
+            await self.close()
 
     async def join(self):
         """


### PR DESCRIPTION
原本的逻辑下，`self.stop()` 调用了 `self._network_future.cancel()`，导致之后 `self.join()` 几乎只可能引发 `CancelledError`，导致后续代码 `self.close()` 不会运行，session 也因此不会正确关闭，会抛 warning。
解决方法是把 `self.close()` 放进 `finally:` 里去。